### PR TITLE
remove v before version name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Taipy Getting Started version:v2.0.0
+# Taipy Getting Started version: 2.0.0
 
 ## License
 Copyright 2022 Avaiga Private Limited


### PR DESCRIPTION
We stopped prefixing the release name with "v" in other repos. I believe we should do the same for the "getting started".

@FabienLelaquais or @florian-vuillemot I don't know how it works on the doc regarding the getting started. I guess it is based on the git tag and not the README. If not, please tell me if I need to change taipy-doc as well.